### PR TITLE
Refactor to MCP Server Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Switch MCP Demo
+# Switch MCP Server Demo
 
-A demonstration of a Model Context Protocol (MCP) client implementation for Nintendo Switch homebrew.
+A demonstration of a Model Context Protocol (MCP) server implementation for Nintendo Switch homebrew.
 
 ## Overview
 
-This project demonstrates how to implement a basic MCP client that can run on Nintendo Switch homebrew environment. The Model Context Protocol allows language models to interact with tools and resources in a standardized way.
+This project demonstrates how to implement a basic MCP server that can run on Nintendo Switch homebrew environment. The Model Context Protocol allows language models to interact with tools and resources in a standardized way.
 
 ## Features
 
@@ -52,15 +52,15 @@ This project demonstrates how to implement a basic MCP client that can run on Ni
 ## Usage
 
 1. Launch the homebrew application from the Switch homebrew menu
-2. The application will initialize the MCP client
-3. Press A to call a demo tool
+2. The application will initialize the MCP server
+3. Press A to start the MCP server
 4. Press + to exit the application
 
 ## Project Structure
 
 - `src/main.cpp` - Main application entry point
-- `src/mcp_client.h` - MCP client header file
-- `src/mcp_client.cpp` - MCP client implementation
+- `src/mcp_server.h` - MCP server header file
+- `src/mcp_server.cpp` - MCP server implementation
 - `data/mcp_config.json` - MCP configuration file
 - `include/json/json.h` - JSON library header (provided by switch-jsoncpp)
 - `Makefile` - Build configuration
@@ -77,7 +77,7 @@ The implementation is designed to be lightweight and efficient for the Switch's 
 
 ## Future Enhancements
 
-- Network connectivity for remote MCP servers
+- Network connectivity for remote MCP clients
 - File system access tools
 - More comprehensive protocol implementation
 - Integration with actual LLM services

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,17 +1,17 @@
 #include <switch.h>
 #include <iostream>
-#include "mcp_client.h"
+#include "mcp_server.h"
 
 int main(int argc, char* argv[]) {
     // Initialize the Switch console
     consoleInit(NULL);
     
     // Print welcome message
-    std::cout << "Switch MCP Demo" << std::endl;
-    std::cout << "Initializing MCP client..." << std::endl;
+    std::cout << "Switch MCP Server Demo" << std::endl;
+    std::cout << "Initializing MCP server..." << std::endl;
     
-    // Initialize MCP client
-    MCPClient client;
+    // Initialize MCP server
+    MCPServer server;
     
     // Main loop
     while(appletMainLoop()) {
@@ -27,8 +27,8 @@ int main(int argc, char* argv[]) {
         }
         
         if (kDown & KEY_A) {
-            std::cout << "A button pressed - calling MCP tool" << std::endl;
-            client.callTool("demo_tool", "{}");
+            std::cout << "A button pressed - starting MCP server" << std::endl;
+            server.start();
         }
         
         // Update the console

--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -1,0 +1,121 @@
+#include "mcp_server.h"
+#include <iostream>
+#include <random>
+#include <chrono>
+
+MCPServer::MCPServer() : isRunning(false) {
+}
+
+MCPServer::~MCPServer() {
+}
+
+bool MCPServer::start() {
+    // In a real implementation, this would start listening for
+    // MCP client connections. For this demo, we'll just simulate success.
+    std::cout << "Starting MCP server..." << std::endl;
+    
+    // Simulate server start
+    isRunning = true;
+    
+    if (isRunning) {
+        std::cout << "MCP server started successfully!" << std::endl;
+        std::cout << "Ready to handle client requests." << std::endl;
+    } else {
+        std::cout << "Failed to start MCP server!" << std::endl;
+    }
+    
+    return isRunning;
+}
+
+void MCPServer::stop() {
+    std::cout << "Stopping MCP server..." << std::endl;
+    isRunning = false;
+    std::cout << "MCP server stopped." << std::endl;
+}
+
+Json::Value MCPServer::handleToolCall(const std::string& toolName, const std::string& params) {
+    std::cout << "Handling tool call: " << toolName << std::endl;
+    
+    // Process a tool call request
+    Json::Value response;
+    response["result"]["content"] = "This is a response from server tool: " + toolName;
+    response["result"]["isError"] = false;
+    
+    return response;
+}
+
+Json::Value MCPServer::listTools() {
+    std::cout << "Listing available tools..." << std::endl;
+    
+    // List of available tools
+    Json::Value response;
+    Json::Value tools(Json::arrayValue);
+    
+    Json::Value tool1;
+    tool1["name"] = "demo_tool";
+    tool1["description"] = "A demonstration tool";
+    tool1["inputSchema"] = Json::Value(Json::objectValue);
+    tools.append(tool1);
+    
+    Json::Value tool2;
+    tool2["name"] = "file_reader";
+    tool2["description"] = "Reads files from the filesystem";
+    tool2["inputSchema"] = Json::Value(Json::objectValue);
+    tools.append(tool2);
+    
+    response["result"]["tools"] = tools;
+    
+    return response;
+}
+
+Json::Value MCPServer::getResource(const std::string& uri) {
+    std::cout << "Getting resource: " << uri << std::endl;
+    
+    // Simulate getting a resource
+    Json::Value response;
+    response["result"]["contents"] = "This is the content of server resource: " + uri;
+    
+    return response;
+}
+
+void MCPServer::processMessages() {
+    if (!isRunning) {
+        std::cout << "Server is not running!" << std::endl;
+        return;
+    }
+    
+    // In a real implementation, this would receive data from clients
+    // and process their requests.
+    std::cout << "Processing client messages" << std::endl;
+}
+
+bool MCPServer::sendMessage(const Json::Value& message) {
+    if (!isRunning) {
+        std::cout << "Server is not running!" << std::endl;
+        return false;
+    }
+    
+    // In a real implementation, this would serialize the JSON message
+    // and send it over the network connection to clients.
+    std::cout << "Sending message to MCP client" << std::endl;
+    
+    return true;
+}
+
+Json::Value MCPServer::receiveMessage() {
+    // In a real implementation, this would receive data from the network
+    // connection from clients and deserialize it into a JSON object.
+    std::cout << "Receiving message from MCP client" << std::endl;
+    
+    Json::Value dummyResponse;
+    return dummyResponse;
+}
+
+std::string MCPServer::generateRequestId() {
+    // Generate a simple random request ID
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> dis(1000, 9999);
+    
+    return "req_" + std::to_string(dis(gen));
+}

--- a/src/mcp_server.h
+++ b/src/mcp_server.h
@@ -1,0 +1,47 @@
+#ifndef MCP_SERVER_H
+#define MCP_SERVER_H
+
+#include <string>
+#include <json/json.h>
+
+class MCPServer {
+public:
+    MCPServer();
+    ~MCPServer();
+    
+    // Start the MCP server
+    bool start();
+    
+    // Stop the MCP server
+    void stop();
+    
+    // Handle a tool call request
+    Json::Value handleToolCall(const std::string& toolName, const std::string& params);
+    
+    // List available tools
+    Json::Value listTools();
+    
+    // Get resource
+    Json::Value getResource(const std::string& uri);
+    
+    // Process incoming messages
+    void processMessages();
+    
+private:
+    // Send a message to the MCP client
+    bool sendMessage(const Json::Value& message);
+    
+    // Receive a message from the MCP client
+    Json::Value receiveMessage();
+    
+    // Generate a unique request ID
+    std::string generateRequestId();
+    
+    // Server state
+    bool isRunning;
+    
+    // Registered tools
+    void registerTools();
+};
+
+#endif // MCP_SERVER_H


### PR DESCRIPTION
This PR refactors the project from an MCP client implementation to an MCP server implementation. The changes include:

1. Renamed MCPClient class to MCPServer with appropriate method names
2. Updated main.cpp to initialize and run an MCP server instead of client
3. Modified the README to reflect the change from client to server implementation
4. Updated method signatures and comments to reflect server functionality

The implementation maintains the same lightweight and efficient design principles but now acts as a server that can handle requests from MCP clients rather than making requests to an MCP server.